### PR TITLE
Add SprayCommandResponse to allow specifying status code and response…

### DIFF
--- a/docs/SprayRoutes.md
+++ b/docs/SprayRoutes.md
@@ -21,7 +21,7 @@ class FooCommand extends Command with SprayGet {
     implicit val executionContext = context.dispatcher
     override def path: String = "/bar"
     override def commandName: String = "Foo"
-    override def execute[T](bean: Option[CommandBean]): Future[CommandResponse[T]] = {
+    override def execute[T](bean: Option[CommandBean]): Future[BaseCommandResponse[T]] = {
         // here is where our business logic
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <scala.version>${scala.artifact.version}.4</scala.version>
         <scoverage.plugin.version>1.1.1</scoverage.plugin.version>
         <spray.version>1.3.2</spray.version>
-        <wookiee.core.version>1.1-SNAPSHOT</wookiee.core.version>
+        <wookiee.core.version>1.1.3</wookiee.core.version>
     </properties>
 
     <groupId>com.webtrends</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <scala.version>${scala.artifact.version}.4</scala.version>
         <scoverage.plugin.version>1.1.1</scoverage.plugin.version>
         <spray.version>1.3.2</spray.version>
+        <wookiee.core.version>1.1-SNAPSHOT</wookiee.core.version>
     </properties>
 
     <groupId>com.webtrends</groupId>
@@ -127,12 +128,12 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>wookiee-core</artifactId>
-            <version>1.1.2</version>
+            <version>${wookiee.core.version}</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>wookiee-test</artifactId>
-            <version>1.1.2</version>
+            <version>${wookiee.core.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/scala/com/webtrends/harness/component/spray/CoreSprayWorker.scala
+++ b/src/main/scala/com/webtrends/harness/component/spray/CoreSprayWorker.scala
@@ -112,20 +112,20 @@ class CoreSprayWorker extends HttpServiceActor
                 complete((healthActor ? HealthRequest(HealthResponseType.LB)).mapTo[String])
               }
             } ~
-            path("nagios") {
-              //time(nagiosHealthTimer) {
+              path("nagios") {
+                //time(nagiosHealthTimer) {
                 respondPlain {
                   complete((healthActor ? HealthRequest(HealthResponseType.NAGIOS)).mapTo[String])
                 }
-              //}
-            } ~
-            path("full") {
-              //time(healthTimer) {
+                //}
+              } ~
+              path("full") {
+                //time(healthTimer) {
                 respondJson {
                   complete((healthActor ? HealthRequest(HealthResponseType.FULL)).mapTo[ApplicationHealth])
                 }
-              //}
-            }
+                //}
+              }
 
           } ~
             path("metrics") {

--- a/src/main/scala/com/webtrends/harness/component/spray/command/SprayCommandResponse.scala
+++ b/src/main/scala/com/webtrends/harness/component/spray/command/SprayCommandResponse.scala
@@ -1,0 +1,10 @@
+package com.webtrends.harness.component.spray.command
+
+import com.webtrends.harness.command.{BaseCommandResponse, CommandResponse}
+import spray.http.{StatusCodes, HttpHeader, StatusCode}
+
+case class SprayCommandResponse[T](override val data: Option[T],
+                              override val responseType: String = "json",
+                              status: StatusCode = StatusCodes.OK,
+                              additionalHeaders: List[HttpHeader] = List()
+                             ) extends BaseCommandResponse[T]

--- a/src/test/scala/com/webtrends/harness/component/spray/command/SprayCommandResponseSpec.scala
+++ b/src/test/scala/com/webtrends/harness/component/spray/command/SprayCommandResponseSpec.scala
@@ -1,0 +1,50 @@
+package com.webtrends.harness.component.spray.command
+
+import akka.testkit.TestActorRef
+import com.webtrends.harness.command.{BaseCommandResponse, CommandResponse, CommandBean}
+import com.webtrends.harness.component.spray.route.RouteManager
+import com.webtrends.harness.component.spray.routes.BaseTestCommand
+import net.liftweb.json.JObject
+import org.specs2.mutable.SpecificationWithJUnit
+import spray.http._
+import spray.routing.{HttpService, Directives}
+import spray.testkit.Specs2RouteTest
+import scala.concurrent.Future
+
+class SprayCommandResponseTestCommand extends BaseTestCommand {
+  override def commandName: String = "SprayCommandResponseTest"
+  override def path: String = "/test/SprayCommandResponse"
+  val responseData = new JObject(List())
+
+  override def execute[T](bean: Option[CommandBean]): Future[SprayCommandResponse[T]] = {
+    Future (new SprayCommandResponse[T](
+      Some(responseData.asInstanceOf[T]),
+      status = StatusCodes.Accepted,
+      additionalHeaders = List (
+        HttpHeaders.RawHeader("custom", "header")
+      )
+    ))
+  }
+}
+
+class SprayCommandResponseSpec extends SpecificationWithJUnit
+  with Directives
+  with Specs2RouteTest
+  with HttpService {
+
+  def actorRefFactory = system
+
+  val testCommandRef = TestActorRef[SprayCommandResponseTestCommand]
+  val testActor = testCommandRef.underlyingActor
+
+  "SprayCommandResponse " should {
+
+    "use specified status code and headers" in {
+      Get("/test/SprayCommandResponse") ~> RouteManager.getRoute("SprayCommandResponseTest_get").get ~> check {
+        status mustEqual StatusCodes.Accepted
+        headers.exists( h => h.name == "custom" && h.value == "header") must beTrue
+      }
+    }
+
+  }
+}

--- a/src/test/scala/com/webtrends/harness/component/spray/routes/TestCommand.scala
+++ b/src/test/scala/com/webtrends/harness/component/spray/routes/TestCommand.scala
@@ -19,7 +19,7 @@
 
 package com.webtrends.harness.component.spray.routes
 
-import com.webtrends.harness.command.{CommandException, CommandResponse, CommandBean, Command}
+import com.webtrends.harness.command._
 import com.webtrends.harness.component.spray.route._
 import spray.http.ContentTypes
 import spray.httpx.marshalling.Marshaller
@@ -36,9 +36,9 @@ import scala.concurrent.Future
  */
 sealed abstract class TestCommand extends Command {
   implicit val executionContext = context.dispatcher
-  override def path: String = "/foo/$key/bar/$key2"
+  override def path: String = "/foo/$key/bar/$key2"sbckmr
 
-  override def execute[T](bean: Option[CommandBean]): Future[CommandResponse[T]] = {
+  override def execute[T](bean: Option[CommandBean]): Future[BaseCommandResponse[T]] = {
     Future {
       bean match {
         case Some(b) =>
@@ -56,7 +56,7 @@ class BaseTestCommand extends TestCommand with SprayGet with SprayHead with Spra
 case class TestObject(stringKey:String, intKey:Int)
 
 sealed abstract class EntityBase extends TestCommand {
-  override def execute[T](bean: Option[CommandBean]): Future[CommandResponse[T]] = {
+  override def execute[T](bean: Option[CommandBean]): Future[BaseCommandResponse[T]] = {
     Future {
       bean match {
         case Some(b) =>

--- a/src/test/scala/com/webtrends/harness/component/spray/routes/TestCommand.scala
+++ b/src/test/scala/com/webtrends/harness/component/spray/routes/TestCommand.scala
@@ -36,7 +36,7 @@ import scala.concurrent.Future
  */
 sealed abstract class TestCommand extends Command {
   implicit val executionContext = context.dispatcher
-  override def path: String = "/foo/$key/bar/$key2"sbckmr
+  override def path: String = "/foo/$key/bar/$key2"
 
   override def execute[T](bean: Option[CommandBean]): Future[BaseCommandResponse[T]] = {
     Future {


### PR DESCRIPTION
@pcross616 @stotten @ladinu @malibuworkcrew @davis20 @mjwallin1 

This allows Spray Commands to return a SprayCommandResponse and specify the status code and headers to use for the response. Backwards compatibility with commands returning CommandResponse is maintained.